### PR TITLE
Add `--workspace-ignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Use [installed-check-core](https://github.com/voxpelli/node-installed-check-core
   * `--no-include-workspace-root` – excludes the workspace root package. Negated equivalent of npm's [`--include-workspace-root`](https://docs.npmjs.com/cli/v10/commands/npm-run-script#include-workspace-root)
   * `--no-workspaces` – excludes workspace packages. Negated equivalent of npm's [`--workspaces`](https://docs.npmjs.com/cli/v10/commands/npm-run-script#workspaces)
   * `--workspace=ARG` / `-w ARG` – excludes all workspace packages not matching these names / paths. Equivalent to npm's [`--workspace` / `-w`](https://docs.npmjs.com/cli/v10/commands/npm-run-script#workspace)
+  * `--workspace-ignore=ARG` – xcludes the specified paths from workspace lookup. (Supports globs)
 
 ### Additional command line options
 

--- a/cli.js
+++ b/cli.js
@@ -29,6 +29,7 @@ const cli = meow(`
     --no-include-workspace-root  Will exclude the workspace root package
     --no-workspaces              Will exclude workspace packages
     -w ARG, --workspace=ARG      Excludes all workspace packages not matching these names / paths
+    --workspace-ignore=ARG       Excludes the specified paths from workspace lookup. (Supports globs)
 
   Options
     --debug        Prints debug info
@@ -52,6 +53,7 @@ const cli = meow(`
     verbose: { shortFlag: 'v', type: 'boolean' },
     versionCheck: { shortFlag: 'c', type: 'boolean' },
     workspace: { shortFlag: 'w', type: 'string', isMultiple: true },
+    workspaceIgnore: { type: 'string', isMultiple: true },
     workspaces: { type: 'boolean', 'default': true },
   },
   importMeta: import.meta,
@@ -73,6 +75,7 @@ const {
   verbose,
   versionCheck,
   workspace,
+  workspaceIgnore,
   workspaces,
 } = cli.flags;
 
@@ -101,6 +104,7 @@ let checks = [
 /** @type {import('installed-check-core').LookupOptions} */
 const lookupOptions = {
   cwd: cli.input[0],
+  ignorePaths: workspaceIgnore,
   includeWorkspaceRoot,
   skipWorkspaces: !workspaces,
   workspace,

--- a/cli.js
+++ b/cli.js
@@ -16,14 +16,14 @@ const cli = meow(`
   Defaults to current folder and to perform all checks.
 
   Checks
-    -e, --engine-check    Override default checks and explicitly request an engine range check.
-    -p, --peer-check      Override default checks and explicitly request a peer dependency range check.
-    -c, --version-check   Override default checks and explicitly request a check of installed versions.
+    -e, --engine-check    Override default checks and explicitly request an engine range check
+    -p, --peer-check      Override default checks and explicitly request a peer dependency range check
+    -c, --version-check   Override default checks and explicitly request a check of installed versions
 
   Check options
-    -i ARG, --ignore=ARG  Excludes the named dependency from non-version checks. (Supports globs)
-    -d, --ignore-dev      Excludes dev dependencies from non-version checks.
-    -s, --strict          Treat warnings as errors.
+    -i ARG, --ignore=ARG  Excludes the named dependency from non-version checks.(Supports globs)
+    -d, --ignore-dev      Excludes dev dependencies from non-version checks
+    -s, --strict          Treat warnings as errors
 
   Workspace options
     --no-include-workspace-root  Will exclude the workspace root package
@@ -32,9 +32,9 @@ const cli = meow(`
 
   Options
     --debug        Prints debug info
-    --help         Print this help and exits.
-    --version      Prints current version and exits.
-    -v, --verbose  Shows warnings.
+    --help         Print this help and exits
+    --version      Prints current version and exits
+    -v, --verbose  Shows warnings
 
   Examples
     $ installed-check

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
-    "installed-check-core": "^8.2.2",
+    "installed-check-core": "^8.2.3",
     "meow": "^12.1.1",
     "pony-cause": "^2.1.10",
     "version-guard": "^1.1.1"


### PR DESCRIPTION
Enables one to do eg. `--workspace-ignore='**/build/**'` to ignore duplicated packages that may exist in build directories, such as the case is in https://github.com/webdriverio/webdriverio/issues/11868#issuecomment-2038272842

Fixes #91